### PR TITLE
Change integration type to helper and streamline device handling

### DIFF
--- a/custom_components/cat_scale/manifest.json
+++ b/custom_components/cat_scale/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/djbios/home-assistant-cat-scale",
-  "integration_type": "device",
+  "integration_type": "helper",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/djbios/home-assistant-cat-scale/issues",
   "quality_scale": "bronze",

--- a/hacs.json
+++ b/hacs.json
@@ -1,3 +1,4 @@
 {
-  "name": "Cat scale: the smart weight sensor for cat litter boxes"
+  "name": "Cat scale: the smart weight sensor for cat litter boxes",
+  "homeassistant": "2025.8.0"
 }

--- a/tests/snapshots/test_integration.ambr
+++ b/tests/snapshots/test_integration.ambr
@@ -3,13 +3,13 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'weight',
-      'friendly_name': 'Cat weight Cat weight',
+      'friendly_name': 'Cat weight',
       'icon': 'mdi:cat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.cat_weight_cat_weight',
+    'entity_id': 'sensor.cat_weight',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -20,12 +20,12 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'weight',
-      'friendly_name': 'Cat weight Baseline',
+      'friendly_name': 'Baseline',
       'icon': 'mdi:scale-balance',
       'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.cat_weight_baseline',
+    'entity_id': 'sensor.baseline',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -36,7 +36,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'enum',
-      'friendly_name': 'Cat weight Detection state',
+      'friendly_name': 'Detection state',
       'icon': 'mdi:radar',
       'options': list([
         'idle',
@@ -46,7 +46,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.cat_weight_detection_state',
+    'entity_id': 'sensor.detection_state',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -57,12 +57,12 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'weight',
-      'friendly_name': 'Cat weight Waste weight',
+      'friendly_name': 'Waste weight',
       'icon': 'mdi:delete-variant',
       'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.cat_weight_waste_weight',
+    'entity_id': 'sensor.waste_weight',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,5 @@
 import pytest
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers import device_registry as dr
 
 pytestmark = pytest.mark.asyncio
 
@@ -8,7 +7,6 @@ pytestmark = pytest.mark.asyncio
 async def test_entities_registered_and_available(init_integration, hass, snapshot):
     """Test that sensor entities are registered, available, and match snapshot."""
     entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
     entries = er.async_entries_for_config_entry(entity_registry, init_integration.entry_id)
     assert entries  # Ensure entities are registered
 
@@ -18,8 +16,3 @@ async def test_entities_registered_and_available(init_integration, hass, snapsho
         assert state is not None
         assert state.state != "unavailable"
         assert state == snapshot
-
-    # Check device registry
-    for entry in entries:
-        device = device_registry.async_get(entry.device_id)
-        assert device is not None


### PR DESCRIPTION
Update the integration to use a helper type instead of a device type.

Simplifying the device handling by fully utilizing the source sensor device. This change is compatible with Home Assistant version 2025.8 and later, so currently tests fail / this is breaking.

See [https://developers.home-assistant.io/blog/2025/07/18/updated-pattern-for-helpers-linking-to-devices/](https://developers.home-assistant.io/blog/2025/07/18/updated-pattern-for-helpers-linking-to-devices/) for more information

Fixes #13 