### PR TITLE
Define cat weight as Median  of all values during presence

### DIFF
--- a/custom_components/cat_scale/sensor.py
+++ b/custom_components/cat_scale/sensor.py
@@ -122,7 +122,10 @@ class CatLitterDetectionSensor(RestoreSensor):
         # Keep recent readings, mostly for debugging or if you need them later
         # Format: deque of (timestamp, weight)
         self._recent_readings = deque()
-        self._recent_presence_readings = deque()
+
+        # Max pollingrate of hx711 is 10hz, so max 10 readings per second, for period cat_present, times 30 to have plenty of space.
+        max_presence_readings: int = 10 * self._leave_timeout.total_seconds() * 30
+        self._recent_presence_readings: deque = deque(maxlen=max_presence_readings)
 
         # Final reported state: last successfully detected cat weight
         self._state = None

--- a/custom_components/cat_scale/sensor.py
+++ b/custom_components/cat_scale/sensor.py
@@ -1,5 +1,5 @@
 from collections import deque
-from datetime import timedelta
+from datetime import timedelta, datetime
 import logging
 import statistics
 

--- a/custom_components/cat_scale/sensor.py
+++ b/custom_components/cat_scale/sensor.py
@@ -251,7 +251,6 @@ class CatLitterDetectionSensor(RestoreSensor):
 
         # Threshold is baseline + cat_weight_threshold
         trigger_level = self._baseline_weight + self._threshold
-
         _LOGGER.debug(
             "%s: Evaluate detection. State=%s, curr=%.2f, baseline=%.2f, threshold=%.2f",
             self._name,
@@ -344,12 +343,12 @@ class CatLitterDetectionSensor(RestoreSensor):
                     detected_cat_weight = 0
 
                 self._state = round(detected_cat_weight, 2)
+
                 _LOGGER.debug(
                     "%s: Cat event recognized. baseline=%.2f, median=%.2f, final=%.2f, presence_values=%s",
                     self._name,
                     self._baseline_weight,
                     median_weight,
-                    detected_cat_weight,
                     self._state,
                     ",".join(map(str, self._recent_presence_readings)),
                 )

--- a/custom_components/cat_scale/sensor.py
+++ b/custom_components/cat_scale/sensor.py
@@ -123,9 +123,8 @@ class CatLitterDetectionSensor(RestoreSensor):
         # Format: deque of (timestamp, weight)
         self._recent_readings = deque()
 
-        # Max pollingrate of hx711 is 10hz, so max 10 readings per second, for period cat_present, times 30 to have plenty of space.
-        max_presence_readings: int = 10 * self._leave_timeout.total_seconds() * 30
-        self._recent_presence_readings: deque = deque(maxlen=max_presence_readings)
+        # Max pollingrate of hx711 is 10hz, with an hour of cat presence
+        self._recent_presence_readings: deque = deque(maxlen=3600 * 10)
 
         # Final reported state: last successfully detected cat weight
         self._state = None

--- a/custom_components/cat_scale/sensor.py
+++ b/custom_components/cat_scale/sensor.py
@@ -275,7 +275,7 @@ class CatLitterDetectionSensor(RestoreSensor):
                 )
                 if len(self._recent_presence_readings) > 0:
                     _LOGGER.error(
-                        "Presence readings weren't properly cleared. Please open an issue with the developers of the cat scale integration to inform them of the occurence of this error on https://github.com/djbios/home-assistant-cat-scale/issues."
+                        "Presence readings were not cleared as expected. This may indicate a bug in the cat scale integration. Please report this issue at https://github.com/djbios/home-assistant-cat-scale/issues and include relevant logs."
                     )
                     self._recent_presence_readings.clear()
                 self._recent_presence_readings.append(current_weight)

--- a/custom_components/cat_scale/sensor.py
+++ b/custom_components/cat_scale/sensor.py
@@ -121,10 +121,10 @@ class CatLitterDetectionSensor(RestoreSensor):
 
         # Keep recent readings, mostly for debugging or if you need them later
         # Format: deque of (timestamp, weight)
-        self._recent_readings = deque()
+        self._recent_readings: deque[tuple[object, float]] = deque()
 
         # Max pollingrate of hx711 is 10hz, with an hour of cat presence
-        self._recent_presence_readings: deque = deque(maxlen=3600 * 10)
+        self._recent_presence_readings: deque[float] = deque(maxlen=3600 * 10)
 
         # Final reported state: last successfully detected cat weight
         self._state = None

--- a/custom_components/cat_scale/sensor.py
+++ b/custom_components/cat_scale/sensor.py
@@ -347,12 +347,11 @@ class CatLitterDetectionSensor(RestoreSensor):
                 self._state = round(detected_cat_weight, 2)
 
                 _LOGGER.debug(
-                    "%s: Cat event recognized. baseline=%.2f, median=%.2f, final=%.2f, presence_values=%s",
+                    "%s: Cat event recognized. baseline=%.2f, median=%.2f, final=%.2f",
                     self._name,
                     self._baseline_weight,
                     median_weight,
                     self._state,
-                    ",".join(map(str, self._recent_presence_readings)),
                 )
 
                 self._detection_state = DetectionState.AFTER_CAT

--- a/custom_components/cat_scale/sensor.py
+++ b/custom_components/cat_scale/sensor.py
@@ -121,7 +121,7 @@ class CatLitterDetectionSensor(RestoreSensor):
 
         # Keep recent readings, mostly for debugging or if you need them later
         # Format: deque of (timestamp, weight)
-        self._recent_readings: deque[tuple[object, float]] = deque()
+        self._recent_readings: deque[tuple[datetime, float]] = deque()
 
         # Max pollingrate of hx711 is 10hz, with an hour of cat presence
         self._recent_presence_readings: deque[float] = deque(maxlen=3600 * 10)

--- a/custom_components/cat_scale/sensor.py
+++ b/custom_components/cat_scale/sensor.py
@@ -352,7 +352,7 @@ class CatLitterDetectionSensor(RestoreSensor):
                     median_weight,
                     detected_cat_weight,
                     self._state,
-                    list(self._recent_presence_readings),
+                    ",".join(map(str, self._recent_presence_readings)),
                 )
 
                 self._detection_state = DetectionState.AFTER_CAT

--- a/custom_components/cat_scale/sensor.py
+++ b/custom_components/cat_scale/sensor.py
@@ -273,7 +273,11 @@ class CatLitterDetectionSensor(RestoreSensor):
                     event_time,
                     self._baseline_weight,
                 )
-                self._recent_presence_readings.clear()
+                if len(self._recent_presence_readings) > 0:
+                    _LOGGER.error(
+                        "Presence readings weren't properly cleared. Please open an issue with the developers of the cat scale integration to inform them of the occurence of this error on https://github.com/djbios/home-assistant-cat-scale/issues."
+                    )
+                    self._recent_presence_readings.clear()
                 self._recent_presence_readings.append(current_weight)
             elif self._recent_readings:
                 # If presumably empty, we can adjust the baseline slowly or with a simple average

--- a/custom_components/cat_scale/sensor.py
+++ b/custom_components/cat_scale/sensor.py
@@ -83,7 +83,6 @@ class DetectionState:
     WAITING_FOR_CONFIRMATION = "waiting_for_confirmation"
     CAT_PRESENT = "cat_present"
     AFTER_CAT = "after_cat"
-    CLEANING = "cleaning"
 
 
 class CatLitterDetectionSensor(RestoreSensor):

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -96,13 +96,20 @@ async def test_noisy_baseline_no_events(make_sensor):
 
 async def test_cat_present_timeout_resets_to_idle(make_sensor):
     """Cat stays present longer than leave_timeout, triggers reset to IDLE."""
-    sensor = await make_sensor(threshold=50, min_time=2, leave_time=3)
+    sensor = await make_sensor(threshold=50, min_time=2, leave_time=20)
     base_wt = 500.0
     cat_delta = 60.0
     start_time = datetime.now()
 
-    # Cat arrives at t=0, stays above threshold for 10 seconds (leave_timeout=3)
-    readings = [(start_time + timedelta(seconds=i), base_wt + cat_delta) for i in range(10)]
+    # Cat arrives at t=0, stays above threshold for 10 seconds (leave_timeout=20)
+    # First, let baseline settle for 5 seconds
+    baseline_readings = [(start_time + timedelta(seconds=i), base_wt) for i in range(5)]
+    # Then, cat present for 30 seconds (above threshold)
+    cat_readings = [
+        (start_time + timedelta(seconds=len(baseline_readings) + i), base_wt + cat_delta)
+        for i in range(30)
+    ]
+    readings = baseline_readings + cat_readings
     for ts, w in readings:
         state = FakeState(str(w), ts)
         event = FakeEvent(state, ts)

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -5,7 +5,7 @@ Pytest suite for Cat Scale Integration.
 import pytest
 import random
 from datetime import datetime, timedelta
-
+from collections import deque
 
 from custom_components.cat_scale.sensor import DetectionState
 from tests.test_data.utils import FakeState, FakeEvent
@@ -92,6 +92,47 @@ async def test_noisy_baseline_no_events(make_sensor):
     assert sensor.state is None
     # baseline ~ 500, allow some margin
     assert sensor.baseline_weight == pytest.approx(500, abs=10)
+
+
+async def test_cat_present_timeout_resets_to_idle(make_sensor):
+    """Cat stays present longer than leave_timeout, triggers reset to IDLE."""
+    sensor = await make_sensor(threshold=50, min_time=2, leave_time=3)
+    base_wt = 500.0
+    cat_delta = 60.0
+    start_time = datetime.now()
+
+    # Cat arrives at t=0, stays above threshold for 10 seconds (leave_timeout=3)
+    readings = [(start_time + timedelta(seconds=i), base_wt + cat_delta) for i in range(10)]
+    for ts, w in readings:
+        state = FakeState(str(w), ts)
+        event = FakeEvent(state, ts)
+        sensor._handle_source_sensor_state_event(event)
+
+    # After leave_timeout, sensor should reset to IDLE and clear readings
+    assert sensor._detection_state == DetectionState.IDLE
+    assert sensor._recent_presence_readings == deque()
+
+
+async def test_cat_left_no_presence_readings_fallback(make_sensor):
+    """If no presence readings, fallback to current_weight for median."""
+    sensor = await make_sensor(threshold=50, min_time=2, leave_time=30)
+    base_wt = 500.0
+    start_time = datetime.now()
+
+    # Simulate: Cat arrives and leaves in one step (never above threshold long enough)
+    readings = [
+        (start_time, base_wt + 60),  # above threshold
+        (start_time + timedelta(seconds=1), base_wt),  # immediately below
+    ]
+    for ts, w in readings:
+        state = FakeState(str(w), ts)
+        event = FakeEvent(state, ts)
+        sensor._handle_source_sensor_state_event(event)
+
+    # No detection, but fallback branch is exercised
+    # (You may need to tweak min_time or logic to force this branch)
+    # Here, just ensure no exception and state is None or 0
+    assert sensor.state is None or sensor.state == 0
 
 
 async def test_cat_come_left_same_baseline(make_sensor):

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -136,9 +136,6 @@ async def test_cat_left_no_presence_readings_fallback(make_sensor):
         event = FakeEvent(state, ts)
         sensor._handle_source_sensor_state_event(event)
 
-    # No detection, but fallback branch is exercised
-    # (You may need to tweak min_time or logic to force this branch)
-    # Here, just ensure no exception and state is None or 0
     assert sensor.state is None or sensor.state == 0
 
 

--- a/tests/test_detection_real_data.py
+++ b/tests/test_detection_real_data.py
@@ -30,8 +30,8 @@ async def test1_csv(make_sensor):
         )
 
     assert sensor._detection_state == DetectionState.IDLE
-    assert sensor.state == pytest.approx(2800, abs=100), "Cat weight should be around 3000g"
-    assert sensor.waste_weight == pytest.approx(30, abs=10), "Waste weight should be around 500g"
+    assert sensor.state == pytest.approx(2575, abs=100), "Cat weight should be around 2575g"
+    assert sensor.waste_weight == pytest.approx(30, abs=10), "Waste weight should be around 30g"
 
 
 async def test2_csv(make_sensor):
@@ -47,5 +47,5 @@ async def test2_csv(make_sensor):
         )
 
     assert sensor._detection_state == DetectionState.IDLE
-    assert sensor.state == pytest.approx(2800, abs=100), "Cat weight should be around 3000g"
+    assert sensor.state == pytest.approx(2227, abs=100), "Cat weight should be around 2227g"
     assert sensor.waste_weight == 0


### PR DESCRIPTION
This PR introduces a different way to calculate the cat weight. Currently we are taking the max during the presence - which in my case often led to big fluctuations in weight when cat jumps / walks / moves.

This PR introduces the use of the median value over all values that were measured during presence. In my case this results in more stable cat weight, and qualitatively looking at some examples a better value.

I'm a bit in doubt about the two testcases for which i just adjusted the expected values to pass, what do you think about it, should we create new test cases?

Fixes #10 