### PR TITLE
Fix esphome example GPIO pins

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -125,8 +125,8 @@ wifi:
 sensor:
   - platform: hx711
     name: "Cat Weight Sensor"
-    dout_pin: GPIO32
-    clk_pin: GPIO26
+    dout_pin: GPIO01
+    clk_pin: GPIO02
 
     gain: 128
     update_interval: 1s

--- a/esphome/example_full_m5stack_scaleset.yaml
+++ b/esphome/example_full_m5stack_scaleset.yaml
@@ -78,8 +78,8 @@ sensor:
     update_interval: 60s
   - platform: hx711
     name: "Cat Weight Sensor"
-    dout_pin: GPIO32
-    clk_pin: GPIO26
+    dout_pin: GPIO01
+    clk_pin: GPIO02
 
     gain: 128
     update_interval: 1s

--- a/esphome/example_slim_m5stack_scaleset.yaml
+++ b/esphome/example_slim_m5stack_scaleset.yaml
@@ -47,8 +47,8 @@ button:
 sensor:
   - platform: hx711
     name: "Cat Weight Sensor"
-    dout_pin: GPIO32
-    clk_pin: GPIO26
+    dout_pin: GPIO01
+    clk_pin: GPIO02
 
     gain: 128
     update_interval: 1s


### PR DESCRIPTION
Small fix for the esphome example.
The GPIO pins were not in line with the example hardware of m5stack that we changed to