### PR TITLE
#31 Presence readings were not cleared as expected triggers on every …

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,8 @@
 coverage:
   status:
+    project:
+      default:
+        enabled: false
     patch:
       default:
         target: 80%

--- a/custom_components/cat_scale/states.py
+++ b/custom_components/cat_scale/states.py
@@ -234,6 +234,7 @@ class BaselineNormalizedTransition(BaseLitterboxTransition):
         context.waste_weight = max(data.weight - context.baseline_weight, 0.0)
         context.baseline_weight = data.weight
         context.recent_readings.clear()
+        context.recent_presence_readings.clear()
 
 
 class LitterboxStateMachine(BaseStateMachine[Reading, LitterboxContext]):

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -182,6 +182,7 @@ async def test_cat_come_left_same_baseline(make_sensor):
     assert sensor.state_machine.waste_weight == pytest.approx(0.0, 0.01), (
         "Waste should be 0 if baseline didn't shift"
     )
+    assert not sensor.state_machine.context.recent_presence_readings
 
 
 async def test_baseline_change_down(make_sensor, hass):


### PR DESCRIPTION
…cat visit